### PR TITLE
Fix typo in nodal traction input file

### DIFF
--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -415,9 +415,11 @@ condition is:
         ],
     },
     "external_loading_conditions": {
-        "concentrated_nodal_forces": {
+        "concentrated_nodal_forces": [
+          {
                "file": "nodal-tractions.txt"
-        }
+          }
+        ]
     }
 ```
 


### PR DESCRIPTION
Input file should be within brackets.