### PR TITLE
Hotfix typo in documentation

### DIFF
--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -34,7 +34,7 @@ The CB-Geo MPM code uses a `JSON` file for input configuration.
     },
     "particles_volumes": "particles-volumes.txt",
     "particles_stresses": "particles-stresses.txt",
-    "particles_cells": "particles-cells.txt",
+    "particle_cells": "particles-cells.txt",
     "isoparametric": false,
     "check_duplicates": false,
     "cell_type": "ED3H8",
@@ -462,6 +462,7 @@ Boundary conditions on the nodes can be specified through as ASCII file. The JSO
 condition is:
 
 ```
+  "mesh": {
     "boundary_conditions": {
         "velocity_constraints": [
             {
@@ -473,14 +474,15 @@ condition is:
                 "file" : "friction-constraints.txt"
             }
         ],
-    },
-    "external_loading_conditions": {
-        "concentrated_nodal_forces": [
-          {
-               "file": "nodal-tractions.txt"
-          }
-        ]
     }
+  },
+  "external_loading_conditions": {
+      "concentrated_nodal_forces": [
+        {
+             "file": "nodal-tractions.txt"
+        }
+      ]
+  }
 ```
 
 #### Velocity constraints

--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -365,11 +365,13 @@ Loading conditions on the nodes can also be specified through an ASCII file. The
 condition is:
 
 ```
-    "external_loading_conditions": {
-        "concentrated_nodal_forces": {
-               "file": "nodal-tractions.txt"
+  "external_loading_conditions": {
+      "concentrated_nodal_forces": [
+        {
+             "file": "nodal-tractions.txt"
         }
-    }
+      ]
+  }
 ```
 
 #### Concentrated nodal forces
@@ -475,13 +477,6 @@ condition is:
             }
         ]
     }
-  },
-  "external_loading_conditions": {
-      "concentrated_nodal_forces": [
-        {
-             "file": "nodal-tractions.txt"
-        }
-      ]
   }
 ```
 

--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -473,7 +473,7 @@ condition is:
             {
                 "file" : "friction-constraints.txt"
             }
-        ],
+        ]
     }
   },
   "external_loading_conditions": {


### PR DESCRIPTION
**Update documentation**

`particles_cells` are supposed to be `particle_cells` according to this [line of the code](https://github.com/cb-geo/mpm/blob/a3ab6bcef10f7489b26d247c53f8fb4dfab2ac4e/include/solvers/mpm_base.tcc#L913).

Boundary conditions are part of `mesh` and does not stand alone like `external_loading_conditions`. Thus to avoid confusion, `mesh` is added before `boundary_conditions`