### PR TITLE
Fix typo and add documentation for particle cell

### DIFF
--- a/user/preprocess/ascii-mesh-particles.md
+++ b/user/preprocess/ascii-mesh-particles.md
@@ -74,3 +74,14 @@ x_n	y_n	z_n
 ```
 
 $x_i$, $y_i$, $z_i$ correspond to the Cartesian coordinates of each material point. The material points are assigned a unique id from 0 to `n - 1`.
+
+The `particles-cell.txt` file which describes the initial cell location of each material point has the following format:
+```
+p_1	c_0
+p_1	c_1
+...
+p_i	c_i
+...
+p_n	c_n
+```
+where $p_i$ is the particle id and $c_i$ is the cell id where particle $p_i$ belongs.

--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -34,7 +34,7 @@ The CB-Geo MPM code uses a `JSON` file for input configuration.
     },
     "particles_volumes": "particles-volumes.txt",
     "particles_stresses": "particles-stresses.txt",
-    "particles_cells": "particles-cells.txt",
+    "particle_cells": "particles-cells.txt",
     "isoparametric": false,
     "check_duplicates": false,
     "cell_type": "ED3H8",
@@ -462,6 +462,7 @@ Boundary conditions on the nodes can be specified through as ASCII file. The JSO
 condition is:
 
 ```
+  "mesh": {
     "boundary_conditions": {
         "velocity_constraints": [
             {
@@ -473,14 +474,15 @@ condition is:
                 "file" : "friction-constraints.txt"
             }
         ],
-    },
-    "external_loading_conditions": {
-        "concentrated_nodal_forces": [
-          {
-               "file": "nodal-tractions.txt"
-          }
-        ]
     }
+  },
+  "external_loading_conditions": {
+      "concentrated_nodal_forces": [
+        {
+             "file": "nodal-tractions.txt"
+        }
+      ]
+  }
 ```
 
 #### Velocity constraints

--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -148,7 +148,7 @@ The `mesh` object define the mesh (node and cells) and boundary conditions. The 
     },
     "particles_volumes": "particles-volumes.txt",
     "particles_stresses": "particles-stresses.txt",
-    "particles_cells": "particles-cells.txt",
+    "particle_cells": "particles-cells.txt",
     "isoparametric": false,
     "check_duplicates": false,
     "cell_type": "ED3H8",

--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -365,11 +365,13 @@ Loading conditions on the nodes can also be specified through an ASCII file. The
 condition is:
 
 ```
-    "external_loading_conditions": {
-        "concentrated_nodal_forces": {
-               "file": "nodal-tractions.txt"
+  "external_loading_conditions": {
+      "concentrated_nodal_forces": [
+        {
+             "file": "nodal-tractions.txt"
         }
-    }
+      ]
+  }
 ```
 
 #### Concentrated nodal forces
@@ -475,13 +477,6 @@ condition is:
             }
         ]
     }
-  },
-  "external_loading_conditions": {
-      "concentrated_nodal_forces": [
-        {
-             "file": "nodal-tractions.txt"
-        }
-      ]
   }
 ```
 

--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -473,7 +473,7 @@ condition is:
             {
                 "file" : "friction-constraints.txt"
             }
-        ],
+        ]
     }
   },
   "external_loading_conditions": {


### PR DESCRIPTION
**Describe the PR**
Add documentation for `particle-cells.txt` file.

**Additional context**
The other items like stresses and volumes use plural noun `particles`. Should we change our code to `particles-cells` instead of `particle-cells` that we have currently?
