### PR TITLE
Adding material_sets to user/preprocess/input.md

### DIFF
--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -245,7 +245,7 @@ Particle injection is a generation technique that can be used to inject particle
 
 ## Material Sets [Optional]
 
-The `material_sets` object defines the relationship between `material_id` and `pset_id`. If provided, this parameter is used to redefine the `material_id` for each provided `pset_id` within the `entity_sets` input JSON. 'material_id' is update prior to the first step. This optional parameter allows for the particles from a single input file to be assigned multiple materials. 
+The `material_sets` object defines the relationship between `material_id` and `pset_id`. If provided, this parameter is used to redefine the `material_id` for each provided `pset_id`. The 'material_id' is updated prior to the first step. This optional parameter allows for the particles from a single input file to be assigned multiple materials. 
 
 ```
   "material_sets": [

--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -245,7 +245,7 @@ Particle injection is a generation technique that can be used to inject particle
 
 ## Material Sets [Optional]
 
-The `material_sets` object defines the relationship between `material_id` and `pset_id`. If provided, this parameter is used to redefine the `material_id` for each provided `pset_id`. The `material_id` is updated prior to the first step. This optional parameter allows for the particles from a single input file to be assigned multiple materials. 
+The `material_sets` object defines the relationship between `material_id` and `pset_id`. If provided, this relationship is used to redefine the `material_id` for each particle associated with the provided `pset_id`. Particle sets and the associated `pset_id` are defined within the `entity_sets` JSON. The `material_id` is updated prior to the first step. This optional parameter allows for the particles from a single input file to be assigned multiple materials. 
 
 ```
   "material_sets": [

--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -245,7 +245,7 @@ Particle injection is a generation technique that can be used to inject particle
 
 ## Material Sets [Optional]
 
-The `material_sets` object defines the relationship between `material_id` and `pset_id`. If provided, this parameter is used to redefine the `material_id` for each provided `pset_id`. The 'material_id' is updated prior to the first step. This optional parameter allows for the particles from a single input file to be assigned multiple materials. 
+The `material_sets` object defines the relationship between `material_id` and `pset_id`. If provided, this parameter is used to redefine the `material_id` for each provided `pset_id`. The `material_id` is updated prior to the first step. This optional parameter allows for the particles from a single input file to be assigned multiple materials. 
 
 ```
   "material_sets": [

--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -84,11 +84,11 @@ The CB-Geo MPM code uses a `JSON` file for input configuration.
   "material_sets": [
     {
       "material_id": 0,
-      "pset_id": 0
+      "pset_id": 2
     },
     {
       "material_id": 1,
-      "pset_id": 1
+      "pset_id": 3
     }
   ],
   "external_loading_conditions": {
@@ -251,11 +251,11 @@ The `material_sets` object defines the relationship between `material_id` and `p
   "material_sets": [
       {
         "material_id": 0,
-        "pset_id": 0
+        "pset_id": 2
       },
       {
         "material_id": 1,
-        "pset_id": 1
+        "pset_id": 3
       }
     ]
 ```

--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -243,6 +243,23 @@ Particle injection is a generation technique that can be used to inject particle
       },
 ```
 
+## Material Sets [Optional]
+
+The `material_sets` object defines the relationship between `material_id` and `pset_id`. If provided, this parameter is used to redefine the `material_id` for each provided `pset_id` within the `entity_sets` input JSON. 'material_id' is update prior to the first step. This optional parameter allows for the particles from a single input file to be assigned multiple materials. 
+
+```
+  "material_sets": [
+      {
+        "material_id": 0,
+        "pset_id": 0
+      },
+      {
+        "material_id": 1,
+        "pset_id": 1
+      }
+    ]
+```
+
 ## Analysis
 
 The `analysis` object defines the type of analysis, number of steps, time-step, and an optional resume support.

--- a/user/preprocess/input.md
+++ b/user/preprocess/input.md
@@ -81,6 +81,16 @@ The CB-Geo MPM code uses a `JSON` file for input configuration.
       "youngs_modulus": 1.5E+06
     }
   ],
+  "material_sets": [
+    {
+      "material_id": 0,
+      "pset_id": 0
+    },
+    {
+      "material_id": 1,
+      "pset_id": 1
+    }
+  ],
   "external_loading_conditions": {
     "concentrated_nodal_forces": [
       {


### PR DESCRIPTION
**Describe the PR**
Add example of `material_sets` for input `JSON` and provide description of new feature in documentation.

**Related Issues/PRs**
https://github.com/cb-geo/mpm/pull/674

**Additional context**
I've selected `pset_id` **2** and **3** since **0** and **1** are defined as the entire set of particles created by "generator" in example input `JSON` (Lines 52 and 62).