### PR TITLE
:pencil::bug: remove extra parentheses

### DIFF
--- a/theory/usl.md
+++ b/theory/usl.md
@@ -13,7 +13,7 @@ Update stress last refers to incrementing the stresses at the material points af
 
 	$$ m_p = \rho V_p $$
 
-* The shape functions ($N_i (\textbf{x}_p^t)$) and the gradient of the shape functions $B_i (\textbf{x}_p^t)$ are computed for each material point $p$, based on the cell in which they are located.
+* The shape functions $N_i (\textbf{x}_p^t)$ and the gradient of the shape functions $B_i (\textbf{x}_p^t)$ are computed for each material point $p$, based on the cell in which they are located.
 
 * The nodal mass and momentum are calculated based on the mass and velocity of all the material points in the cell and are mapped to the nodes using the shape functions.
 


### PR DESCRIPTION
**Describe the PR**
Potential fix for this behavior on cb-geo site in `USL` tab:
![image](https://user-images.githubusercontent.com/62029065/93285217-35001700-f789-11ea-996f-5598e8cb34ff.png)

[LINK TO BEHAVIOR](https://mpm.cb-geo.com/#/theory/usl)



**Related Issues/PRs**
n/a


**Additional context**
Behavior verified on:
* Firefox
* Chrome
* Edge
