### PR TITLE
:pencil::bug: fix Kirsch equation

### DIFF
--- a/user/validation/explicit/plate-hole/plate-hole.md
+++ b/user/validation/explicit/plate-hole/plate-hole.md
@@ -11,7 +11,7 @@ $\sigma_{rr}=\frac{\sigma_0}{2}(1-(\frac{a}{r})^2)+\frac{\sigma_0}{2}(1-4(\frac{
 
 $\sigma_{\theta\theta}=\frac{\sigma_0}{2}(1+(\frac{a}{r})^2)-\frac{\sigma_0}{2}(1+3(\frac{a}{r})^4)cos2\theta$
 
-$\tau_{r\theta}=-\frac{\sigma_0}{2}(1+2(\frac{a}{r})^2-3(\frac{a}{r}^4))sin2\theta$
+$\tau_{r\theta}=-\frac{\sigma_0}{2}(1+2(\frac{a}{r})^2-3(\frac{a}{r})^4)sin2\theta$
 
 where _a_ is hole radius, _r_ and $\theta$ are radial coordinates and $\sigma_0$ is remote stress. The stress concentration factor, $K_t$ which is defined as the ratio of the maximum stress, $\sigma_{max}$ at hole to the remote stress, $\sigma_0$ for the infinite width plate is 3.
 


### PR DESCRIPTION
**Describe the PR**
Put `^4` outside parenthesis:
![image](https://user-images.githubusercontent.com/62029065/95289695-42587080-0820-11eb-969c-90430538090b.png)


**Related Issues/PRs**
n/a

**Additional context**
Repeatedly getting tripped up until checking [wikipedia](https://en.wikipedia.org/wiki/Kirsch_equations):
![image](https://user-images.githubusercontent.com/62029065/95289763-6d42c480-0820-11eb-9ed0-e2600de2b4f9.png)

